### PR TITLE
Use VecNormalize for PPO

### DIFF
--- a/PolicyTester.py
+++ b/PolicyTester.py
@@ -1,5 +1,6 @@
 import time
 from stable_baselines3 import PPO
+from stable_baselines3.common.vec_env import DummyVecEnv, VecNormalize
 from CNNMLPPolicy import CNNMLPPolicy
 
 from Environment import StableEnvironment
@@ -43,8 +44,9 @@ def test_policy(model_path: str, stable_csv: str, horse_xls: str):
     stable_list = read_csv_stables_to_list(stable_csv)
     horse_list = read_xls_horses(horse_xls)
 
-    env = StableEnvironment(stable_list, horse_list)
-    model = PPO.load(model_path)
+    env = DummyVecEnv([lambda: StableEnvironment(stable_list, horse_list, normalize_output=False)])
+    env = VecNormalize.load("model_PPO/vec_normalize.pkl", env)
+    model = PPO.load(model_path, env=env)
 
     obs, _ = env.reset()
     done = False

--- a/Testing.py
+++ b/Testing.py
@@ -1,12 +1,14 @@
 from stable_baselines3 import PPO
+from stable_baselines3.common.vec_env import DummyVecEnv, VecNormalize
 
 from Environment import StableEnvironment
 from Functions import save_grid_contents_to_excel
 
 def test_model_ppo(stable_list, horse_list, model_name):
     # Załaduj zapisany model
-    model = PPO.load(model_name)
-    env = StableEnvironment(stable_list, horse_list)
+    env = DummyVecEnv([lambda: StableEnvironment(stable_list, horse_list, normalize_output=False)])
+    env = VecNormalize.load("model_PPO/vec_normalize.pkl", env)
+    model = PPO.load(model_name, env=env)
 
     # Przetestuj agenta w środowisku
     obs, info = env.reset()

--- a/Train.py
+++ b/Train.py
@@ -1,4 +1,5 @@
 from stable_baselines3 import PPO
+from stable_baselines3.common.vec_env import DummyVecEnv, VecNormalize
 import torch as th
 from CNNMLPPolicy import CNNMLPPolicy
 from Environment import StableEnvironment
@@ -7,7 +8,10 @@ from Environment import StableEnvironment
 
 def train_model_ppo(stable_list, horse_list, policy, policy_path=None):
     # Disable internal normalization to use raw observations and rewards
-    env = StableEnvironment(stable_list, horse_list, normalize_output=False)
+    env = DummyVecEnv([
+        lambda: StableEnvironment(stable_list, horse_list, normalize_output=False)
+    ])
+    env = VecNormalize(env, norm_obs=True, norm_reward=True)
 
     # last change ent_coef 0.2-> 0.1 vf_coef 1.5 -> 1
     # Tworzenie algorytmu PPO z hybrydową siecią CNN-MLP
@@ -27,3 +31,4 @@ def train_model_ppo(stable_list, horse_list, policy, policy_path=None):
         iteration += 1
         model.learn(total_timesteps=50000, tb_log_name="run_1")
         model.save(f"model_PPO/stable_environment_CNNMLP_{iteration}")
+        env.save("model_PPO/vec_normalize.pkl")


### PR DESCRIPTION
## Summary
- wrap StableEnvironment in DummyVecEnv and VecNormalize when training PPO
- persist VecNormalize statistics
- load models with VecNormalize in testers

## Testing
- `python -m py_compile Train.py PolicyTester.py Testing.py`

------
https://chatgpt.com/codex/tasks/task_e_684eb1c052808328a550e46dbcc1be47