### PR TITLE
Remove optional normalization

### DIFF
--- a/Environment.py
+++ b/Environment.py
@@ -254,11 +254,10 @@ class StableEnvironment(gym.Env):
         print(f"Encoded grid_contents shape: {self.encoded_grid_contents.shape}")
         print(f"Original observation_space shape: {self.original_observation_space['grid_contents'].shape}")
 
-        flat_observation = flatten(self.original_observation_space,observation)
+        flat_observation = flatten(self.original_observation_space, observation)
 
         self.update_normalization_stats(flat_observation)
         flat_observation = self.normalize_observation(flat_observation)
-
 
         return flat_observation, {}
 
@@ -530,11 +529,22 @@ class StableEnvironment(gym.Env):
 
 
 
-        observation = flatten(self.original_observation_space ,{"stable": self.stable_list, "agent_position": self.agent_position, "horse_list": self.encoded_horse_list,"grid_contents": self.encoded_grid_contents, "current_horse_index": np.array([self.current_horse_index])})
+        observation = flatten(
+            self.original_observation_space,
+            {
+                "stable": self.stable_list,
+                "agent_position": self.agent_position,
+                "horse_list": self.encoded_horse_list,
+                "grid_contents": self.encoded_grid_contents,
+                "current_horse_index": np.array([self.current_horse_index]),
+            },
+        )
+
         # Dynamiczna aktualizacja statystyk
         self.update_normalization_stats(observation)
         self.update_reward_stats(reward)
         observation = self.normalize_observation(observation)
         reward = self.normalize_reward(reward)
+
         truncated = False
         return observation, reward, done, truncated, {}

--- a/Train.py
+++ b/Train.py
@@ -25,4 +25,4 @@ def train_model_ppo(stable_list, horse_list, policy, policy_path=None):
     while True:
         iteration += 1
         model.learn(total_timesteps=50000, tb_log_name="run_1")
-        model.save(f"{"model_PPO"}/stable_environment_gnn_{iteration}")
+        model.save(f"model_PPO/stable_environment_gnn_{iteration}")


### PR DESCRIPTION
## Summary
- revert `StableEnvironment` parameter for normalization
- revert PPO training to use default environment
- keep corrected save path for models

## Testing
- `python -m py_compile Environment.py Train.py`

------
https://chatgpt.com/codex/tasks/task_e_684d94b8deb483288d10103cd78a591d