### PR TITLE
Maintain fixed encoders

### DIFF
--- a/Environment.py
+++ b/Environment.py
@@ -1,6 +1,7 @@
 import gymnasium as gym
 import numpy as np
 import math
+from sklearn.preprocessing import LabelEncoder
 
 from gymnasium.spaces import flatten_space, flatten
 
@@ -58,6 +59,14 @@ class StableEnvironment(gym.Env):
         self.max_horse_id = max(self.horse_list, key=lambda x: x[0])[0]
         self.max_horse_team = max(self.horse_list, key=lambda x: x[6])[6]
         self.encoded_horse_list = encode_horse_list(horse_list)
+        # Create label encoders once using full horse_list
+        self.encoders = {
+            "name": LabelEncoder().fit(horse_list["Imię"]),
+            "surname": LabelEncoder().fit(horse_list["Nazwisko"]),
+            "country": LabelEncoder().fit(horse_list["Kraj (Zawodnik)"]),
+            "horse_name": LabelEncoder().fit(horse_list["Nazwa"]),
+        }
+
         self.encoded_grid_contents = np.zeros((*self.grid_size, 8), dtype=np.float32)
 
         # Stan - informacje o stajni i pozycji agenta
@@ -370,7 +379,14 @@ class StableEnvironment(gym.Env):
                 # Umieszczenie konia na planszy
                 self.place_horse((x, y), horse_data)
                 self.horses_remaining -= 1
-                self.encoded_grid_contents = encode_grid_contents(self.grid_contents, self.encoded_grid_contents, self.grid_size, self.max_horse_id, self.max_horse_team)
+                self.encoded_grid_contents = encode_grid_contents(
+                    self.grid_contents,
+                    self.encoded_grid_contents,
+                    self.grid_size,
+                    self.max_horse_id,
+                    self.max_horse_team,
+                    self.encoders,
+                )
 
 
                 reward += 1  # Standardowa nagroda za umieszczenie konia
@@ -476,7 +492,14 @@ class StableEnvironment(gym.Env):
         elif action == 5:
             if self.healing_boxes_remaining > 0 and (x, y) not in self.grid_contents:
                 self.place_healing_box((x, y))
-                self.encoded_grid_contents = encode_grid_contents(self.grid_contents,self.encoded_grid_contents, self.grid_size, self.max_horse_id, self.max_horse_team)
+                self.encoded_grid_contents = encode_grid_contents(
+                    self.grid_contents,
+                    self.encoded_grid_contents,
+                    self.grid_size,
+                    self.max_horse_id,
+                    self.max_horse_team,
+                    self.encoders,
+                )
 
                 #reward += 5  # Nagroda za umieszczenie boksu leczącego
 
@@ -520,7 +543,14 @@ class StableEnvironment(gym.Env):
         elif action == 6:
             if self.antidoping_boxes_remaining > 0 and (x, y) not in self.grid_contents:
                 self.place_antidoping_box((x, y))
-                self.encoded_grid_contents = encode_grid_contents(self.grid_contents,self.encoded_grid_contents, self.grid_size, self.max_horse_id, self.max_horse_team)
+                self.encoded_grid_contents = encode_grid_contents(
+                    self.grid_contents,
+                    self.encoded_grid_contents,
+                    self.grid_size,
+                    self.max_horse_id,
+                    self.max_horse_team,
+                    self.encoders,
+                )
 
                 #reward += 5  # Nagroda za umieszczenie boksu antydopingowego
 

--- a/Functions.py
+++ b/Functions.py
@@ -80,7 +80,7 @@ def encode_horse_list(horse_list):
     return encoded_horse_list
 
 
-def encode_grid_contents(grid_contents, grid_array=None, grid_size=(10, 10), max_horse_number=400, max_team=15):
+def encode_grid_contents(grid_contents, grid_array=None, grid_size=(10, 10), max_horse_number=400, max_team=15, encoders=None):
     """
     Funkcja kodująca dane grid_contents do tablicy NumPy z uwzględnieniem unikalnego numeru konia.
 
@@ -97,20 +97,14 @@ def encode_grid_contents(grid_contents, grid_array=None, grid_size=(10, 10), max
         num_features = 8  # Liczba cech: numer_konia, horse_id, player_id, gender, team, important
         grid_array = np.zeros((grid_size[0], grid_size[1], num_features), dtype=np.float32)
 
-    name_encoder = LabelEncoder()
-    surname_encoder = LabelEncoder()
-    country_encoder = LabelEncoder()
-    horse_name_encoder = LabelEncoder()
-    gender_mapping = {"Mare": 0, "Gelding": 1, "Stallion": 2}
+    if encoders is None:
+        raise ValueError("Encoders dictionary is required")
 
-    all_surnames = [content["data"][2] for content in grid_contents.values() if content["type"] == "horse"]
-    surname_encoder.fit(all_surnames)
-    all_countries = [content["data"][4] for content in grid_contents.values() if content["type"] == "horse"]
-    country_encoder.fit(all_countries)
-    all_horse_names = [content["data"][1] for content in grid_contents.values() if content["type"] == "horse"]
-    horse_name_encoder.fit(all_horse_names)
-    all_names = [content["data"][3] for content in grid_contents.values() if content["type"] == "horse"]
-    name_encoder.fit(all_names)
+    name_encoder = encoders["name"]
+    surname_encoder = encoders["surname"]
+    country_encoder = encoders["country"]
+    horse_name_encoder = encoders["horse_name"]
+    gender_mapping = {"Mare": 0, "Gelding": 1, "Stallion": 2}
 
 
     for (x, y), content in grid_contents.items():


### PR DESCRIPTION
## Summary
- initialize label encoders once in `StableEnvironment` from `horse_list`
- allow `encode_grid_contents` to reuse pre-fitted encoders
- update calls to pass these encoders

## Testing
- `python3 -m py_compile Environment.py Functions.py`

------
https://chatgpt.com/codex/tasks/task_e_684f4d6c70b88328bd539722775676ef