### PR TITLE
Add simple MaskablePPO and integrate action mask

### DIFF
--- a/MaskablePPO.py
+++ b/MaskablePPO.py
@@ -1,0 +1,40 @@
+import numpy as np
+
+try:
+    from stable_baselines3 import PPO
+except Exception:  # pragma: no cover - stable_baselines3 may be missing
+    PPO = object  # type: ignore
+
+
+class MaskablePPO(PPO):  # type: ignore[misc]
+    """Simple PPO variant that avoids invalid actions using an action mask."""
+
+    def predict(self, observation, state=None, episode_start=None, deterministic=False, action_mask=None):
+        action, state = super().predict(observation, state, episode_start, deterministic)
+
+        if action_mask is None:
+            env = getattr(self, "env", None)
+            if env is not None:
+                if hasattr(env, "get_action_mask"):
+                    action_mask = env.get_action_mask()
+                elif hasattr(env, "envs"):
+                    # VecEnv
+                    action_mask = np.array([e.get_action_mask() for e in env.envs])
+
+        if action_mask is not None:
+            action = self._apply_mask(action, action_mask)
+        return action, state
+
+    @staticmethod
+    def _apply_mask(action, mask):
+        mask = np.array(mask)
+        if mask.ndim == 2:
+            for i, act in enumerate(np.atleast_1d(action)):
+                if mask[i, act] == 0:
+                    valid = np.flatnonzero(mask[i])
+                    action[i] = np.random.choice(valid)
+        else:
+            if mask[action] == 0:
+                valid = np.flatnonzero(mask)
+                action = np.random.choice(valid)
+        return action

--- a/PolicyTester.py
+++ b/PolicyTester.py
@@ -1,8 +1,9 @@
 import time
-from stable_baselines3 import PPO
+from MaskablePPO import MaskablePPO
 
 
 from Environment import StableEnvironment
+from ActionMaskWrapper import ActionMaskWrapper
 from Functions import read_csv_stables_to_list, read_xls_horses, save_grid_contents_to_excel
 
 
@@ -65,8 +66,8 @@ def test_policy(model_path: str, stable_csv: str, horse_xls: str):
     stable_list = read_csv_stables_to_list(stable_csv)
     horse_list = read_xls_horses(horse_xls)
 
-    env = StableEnvironment(stable_list, horse_list)
-    model = PPO.load(model_path)
+    env = ActionMaskWrapper(StableEnvironment(stable_list, horse_list))
+    model = MaskablePPO.load(model_path, env=env)
 
     obs, _ = env.reset()
     done = False

--- a/Train.py
+++ b/Train.py
@@ -1,4 +1,4 @@
-from stable_baselines3 import PPO
+from MaskablePPO import MaskablePPO
 import torch as th
 from CNNMLPPolicy import CNNMLPPolicy
 from Environment import StableEnvironment
@@ -12,14 +12,14 @@ def train_model_ppo(stable_list, horse_list, policy, policy_path=None):
 
     # last change ent_coef 0.2-> 0.1 vf_coef 1.5 -> 1
     # Tworzenie algorytmu PPO z hybrydową siecią CNN-MLP
-    model = PPO(policy, env, verbose=1,
+    model = MaskablePPO(policy, env, verbose=1,
                 device='cuda', ent_coef=0.1, clip_range=0.2, vf_coef=1, gamma=0.98,
                 learning_rate=0.0003,
                 policy_kwargs=dict(original_observation_space=base_env.original_observation_space),
                 normalize_advantage=True,
                 tensorboard_log="./ppo_tensorboard/")
 
-    #model.policy.load_state_dict(PPO.load(policy_path, env=env).policy.state_dict())
+    #model.policy.load_state_dict(MaskablePPO.load(policy_path, env=env).policy.state_dict())
     #print(f"Loaded policy from {policy_path}")
 
     # Trening modelu


### PR DESCRIPTION
## Summary
- introduce `MaskablePPO` that respects action masks when predicting
- use `MaskablePPO` in training
- adjust `PolicyTester` to load and run with the action-masked PPO

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f4d90d8848328956963d9bb72a9ca