### PR TITLE
Add policy evaluation function

### DIFF
--- a/PolicyTester.py
+++ b/PolicyTester.py
@@ -102,6 +102,44 @@ def test_policy(model_path: str, stable_csv: str, horse_xls: str):
     print(f"Ważni zawodnicy na polu 2: {important_on_2}")
 
 
+def evaluate_policy(model_path: str, stable_csv: str, horse_xls: str, runs: int = 1000):
+    """Run a trained policy multiple times and report average metrics and reward."""
+    stable_list = read_csv_stables_to_list(stable_csv)
+    horse_list = read_xls_horses(horse_xls)
+
+    model = PPO.load(model_path)
+
+    metrics_sum = [0, 0, 0, 0, 0, 0]
+    reward_sum = 0.0
+
+    env = StableEnvironment(stable_list, horse_list)
+    for _ in range(runs):
+        obs, _ = env.reset()
+        done = False
+        total_reward = 0.0
+        while not done:
+            action, _ = model.predict(obs, deterministic=False)
+            obs, reward, done, truncated, _ = env.step(action)
+            total_reward += float(reward)
+
+        reward_sum += total_reward
+        metrics = _compute_adjacent_metrics(env)
+        metrics_sum = [m + v for m, v in zip(metrics_sum, metrics)]
+
+    avg_metrics = [m / runs for m in metrics_sum]
+    avg_reward = reward_sum / runs
+
+    print(f"Średnia łączna nagroda: {avg_reward:.2f}")
+    print(f"Średnia ogierów obok siebie: {avg_metrics[0]:.2f}")
+    print(f"Średnia klaczy obok ogierów: {avg_metrics[1]:.2f}")
+    print(f"Średnia koni o tym samym nazwisku obok siebie: {avg_metrics[2]:.2f}")
+    print(f"Średnia zawodników z tego samego kraju obok siebie: {avg_metrics[3]:.2f}")
+    print(f"Średnia zawodników z tego samego zespołu obok siebie: {avg_metrics[4]:.2f}")
+    print(f"Średnia ważnych zawodników na polu 2: {avg_metrics[5]:.2f}")
+
+    return avg_metrics, avg_reward
+
+
 if __name__ == "__main__":
     import argparse
 
@@ -109,6 +147,11 @@ if __name__ == "__main__":
     parser.add_argument("--model", required=True, help="Path to the trained model")
     parser.add_argument("--stable", default="testowa_stajnia.csv", help="CSV file with stable layout")
     parser.add_argument("--horses", default="test_lista_koni_40.xls", help="Excel file with horse list")
+    parser.add_argument("--evaluate", action="store_true", help="Run multiple evaluations")
+    parser.add_argument("--runs", type=int, default=1000, help="Number of evaluation runs")
     args = parser.parse_args()
 
-    test_policy(args.model, args.stable, args.horses)
+    if args.evaluate:
+        evaluate_policy(args.model, args.stable, args.horses, args.runs)
+    else:
+        test_policy(args.model, args.stable, args.horses)


### PR DESCRIPTION
## Summary
- extend `PolicyTester.py` with `evaluate_policy` for running a trained policy multiple times
- add CLI options to run this evaluation mode

## Testing
- `python -m py_compile PolicyTester.py`

------
https://chatgpt.com/codex/tasks/task_e_68501ccfd6388328ba164a46a62d7a53